### PR TITLE
Add async tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ tokio = { version = "1.13.0", features = ["full"] }
 reqwest = { version = "0.11.6", features = ["json" ] }
 serde = { version = "1.0", features = ["derive"] }
 
+[dev-dependencies]
+httpmock = "0.6.4"
+
 [[example]]
 name = "main"
 

--- a/tests/async_logging_from_async_runtime.rs
+++ b/tests/async_logging_from_async_runtime.rs
@@ -1,0 +1,19 @@
+use httpmock::prelude::*;
+
+#[tokio::test]
+async fn async_logging_from_async_runtime() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/loki/api/v1/push");
+        then.status(200);
+    });
+
+    loki_logger::init(server.url("/loki/api/v1/push"), log::LevelFilter::Info).unwrap();
+
+    log::info!("Logged into Loki !");
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    mock.assert();
+}

--- a/tests/async_logging_from_sync_thread.rs
+++ b/tests/async_logging_from_sync_thread.rs
@@ -1,0 +1,21 @@
+use httpmock::prelude::*;
+
+#[tokio::test]
+async fn async_logging_from_sync_thread() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/loki/api/v1/push");
+        then.status(200);
+    });
+
+    loki_logger::init(server.url("/loki/api/v1/push"), log::LevelFilter::Info).unwrap();
+
+    std::thread::spawn(|| {
+        log::info!("Logged into Loki !");
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    mock.assert();
+}


### PR DESCRIPTION
Add two async tests. One of them (`async_logging_from_sync_thread`) causes an error with the message `there is no reactor running, must be called from the context of a Tokio 1.x runtime`. See issue #1 for more details.

I put the tests into separate file in order to avoid initializing the logger twice in a single application.